### PR TITLE
make benchmark_kv_stream.py compatible with Windows

### DIFF
--- a/benchmarks/benchmark_kv_stream.py
+++ b/benchmarks/benchmark_kv_stream.py
@@ -20,6 +20,7 @@ import urllib.request
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SERVER_BIN = "Release/llama-server.exe" if os.name == "nt" else "llama-server"
 CONTEXT_STEP = 8192
 UVM_ENV_NAMES = (
     "GGML_CUDA_ENABLE_UNIFIED_MEMORY",
@@ -86,7 +87,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--server",
         type=Path,
-        default=ROOT / "build/bin/llama-server",
+        default=ROOT / "build/bin" / SERVER_BIN,
         help="adaptive KV streaming llama-server binary",
     )
     parser.add_argument(
@@ -143,6 +144,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     args.model = args.model.resolve()
     args.server = args.server.resolve()
+    if not args.server.is_file():
+        exe_server = args.server.with_suffix(".exe").resolve()
+        if exe_server.is_file():
+            args.server = exe_server
     return args
 
 
@@ -337,7 +342,10 @@ class Server:
 
     def stop(self) -> None:
         if self.process is not None and self.process.poll() is None:
-            self.process.send_signal(signal.SIGINT)
+            terminate_signal = (
+                signal.CTRL_C_EVENT if os.name == "nt" else signal.SIGINT
+            )
+            self.process.send_signal(terminate_signal)
             try:
                 self.process.wait(timeout=8)
             except subprocess.TimeoutExpired:
@@ -792,7 +800,10 @@ def plot_results(output_dir: Path, rows: dict[int, dict], plt) -> None:
 def validate_args(args: argparse.Namespace) -> None:
     if not args.model.is_file():
         raise SystemExit(f"model not found: {args.model}")
-    if not args.server.is_file() or not os.access(args.server, os.X_OK):
+    server_ok = args.server.is_file() and (
+        os.name == "nt" or os.access(args.server, os.X_OK)
+    )
+    if not server_ok:
         raise SystemExit(f"server is not executable: {args.server}")
     numeric_positive = (
         args.decode_tokens,

--- a/benchmarks/benchmark_kv_stream.py
+++ b/benchmarks/benchmark_kv_stream.py
@@ -345,12 +345,22 @@ class Server:
             terminate_signal = (
                 signal.CTRL_C_EVENT if os.name == "nt" else signal.SIGINT
             )
-            self.process.send_signal(terminate_signal)
+            # On Windows, CTRL_C_EVENT reaches the shared console and would
+            # interrupt this benchmark process itself; mask SIGINT while we
+            # send it so the child stops but we keep running.
+            previous_handler = None
+            if os.name == "nt":
+                previous_handler = signal.signal(signal.SIGINT, lambda *_: None)
             try:
-                self.process.wait(timeout=8)
-            except subprocess.TimeoutExpired:
-                self.process.kill()
-                self.process.wait(timeout=10)
+                self.process.send_signal(terminate_signal)
+                try:
+                    self.process.wait(timeout=8)
+                except subprocess.TimeoutExpired:
+                    self.process.kill()
+                    self.process.wait(timeout=10)
+            finally:
+                if previous_handler is not None:
+                    signal.signal(signal.SIGINT, previous_handler)
         if not self.log_file.closed:
             self.log_file.close()
 


### PR DESCRIPTION
# `benchmark_kv_stream.py` is unusable on Windows

- **Description** — The adaptive-KV streaming benchmark (`benchmarks/benchmark_kv_stream.py`) cannot be run on Windows. Two independent defects break it: the `--server` default is hardcoded to the Linux single-config build layout (so argument validation fails before any process is spawned), and `Server.stop` signals the child with `SIGINT`, which Windows `subprocess` rejects — and the Windows-valid `CTRL_C_EVENT` reaches the shared console and interrupts the benchmark itself.
- **Impact** — A Windows user cannot run the benchmark at all. Without a `--server` override it exits before any spawn; with an override it crashes (or self-aborts) at the first server shutdown. No sweep and no plot are produced.
- **Reproduction** — *Established this session by inspection of the source plus targeted CPython verification. The full Windows benchmark (a CUDA build + a model + GPU) and the console-wide `CTRL_C_EVENT` event were not re-executed here, so the exit-130 self-interrupt is grounded by the shared-console `Popen` and CPython's `os.kill` / `GenerateConsoleCtrlEvent` routing rather than a re-run.*
  **Environment** — Windows; a CUDA-enabled CMake/MSVC build of the repo (server at `build/bin/Release/llama-server.exe`); an NVIDIA GPU with `nvidia-smi` on `PATH`; a GGUF model file on disk; Python with `matplotlib`.
  **Starting state** — a clean checkout of this code with a built `Release` tree present.
  1. `python benchmarks\benchmark_kv_stream.py --model <model> --output <dir> --probe-only`
  2. Without a `--server` override it exits `server is not executable: build\bin\llama-server` before the first spawn (Bug 1).
  3. With `--server build\bin\Release\llama-server.exe`, validation passes; the first server stop raises `ValueError: Unsupported signal: 2` (Bug 2). With a `CTRL_C_EVENT` shutdown and no handler masking, the sweep aborts itself with `Sweep interrupted; completed points remain resumable.` and exit 130 (Bug 2).
- **Expected Result** — The benchmark runs on Windows: it locates the built server by default, launches it, completes the sweep, and stops each server cleanly — no `ValueError`, no self-interrupt.
- **Observed Result** — (a) without `--server`, `SystemExit: server is not executable: build\bin\llama-server` before any spawn; (b) with `--server`, the first `Server.stop()` raises `ValueError: Unsupported signal: 2`; (c) with a `CTRL_C_EVENT` shutdown and no masking, the sweep aborts on the first stop with `Sweep interrupted; completed points remain resumable.` and exit 130, with `pool_probe.jsonl` written but no `results.jsonl`.

## Bugs

### Bug 1: `--server` default is hardcoded to the Linux build layout

- **Location** — `parse_args` (`benchmark_kv_stream.py:62`); the `--server` default (line 89); `validate_args` (line 792), the server check (line 795).
- **Root Cause** — `parse_args` defaults `--server` to `ROOT / "build/bin/llama-server"` (line 89) — the single-config Linux layout with no `.exe`. A Windows CMake/MSVC multi-config build places the server at `build/bin/Release/llama-server.exe`, so `validate_args`'s `args.server.is_file()` (line 795) is false and it exits `server is not executable`. The adjacent `os.access(args.server, os.X_OK)` is not itself a cause — it returns `True` for an existing `.exe` — but the default never resolves to the `.exe`, so the `is_file()` check fails first.
- **Trigger** — running the benchmark on Windows without a `--server` override.
- **Evidence** — the default (`benchmark_kv_stream.py:89`) is `build/bin/llama-server`; a Windows multi-config build places the server at `build/bin/Release/llama-server.exe`, so the default resolves to a non-existent file and `validate_args` exits `server is not executable: build\bin\llama-server`.
- **Fix** — a platform-aware default plus a `.exe` fallback:
  ```diff
  # benchmark_kv_stream.py:22
   import urllib.request
 
   
   ROOT = Path(__file__).resolve().parents[1]
  +SERVER_BIN = "Release/llama-server.exe" if os.name == "nt" else "llama-server"
   CONTEXT_STEP = 8192
  ```
  ```diff
  # benchmark_kv_stream.py:89
       parser.add_argument(
           "--server",
           type=Path,
  -        default=ROOT / "build/bin/llama-server",
  +        default=ROOT / "build/bin" / SERVER_BIN,
           help="adaptive KV streaming llama-server binary",
       )
  ```
  ```diff
  # benchmark_kv_stream.py:145
       args = parser.parse_args(argv)
       args.model = args.model.resolve()
       args.server = args.server.resolve()
  +    if not args.server.is_file():
  +        exe_server = args.server.with_suffix(".exe").resolve()
  +        if exe_server.is_file():
  +            args.server = exe_server
       return args
  ```
  ```diff
  # benchmark_kv_stream.py:795
   def validate_args(args: argparse.Namespace) -> None:
       if not args.model.is_file():
           raise SystemExit(f"model not found: {args.model}")
  -    if not args.server.is_file() or not os.access(args.server, os.X_OK):
  +    server_ok = args.server.is_file() and (
  +        os.name == "nt" or os.access(args.server, os.X_OK)
  +    )
  +    if not server_ok:
           raise SystemExit(f"server is not executable: {args.server}")
  ```

### Bug 2: `Server.stop` shutdown is not Windows-compatible

- **Location** — `Server.stop` (`benchmark_kv_stream.py:338`); `self.process.send_signal(signal.SIGINT)` (line 340).
- **Root Cause** — `Server.stop` (line 338) sends `self.process.send_signal(signal.SIGINT)` (line 340). On Windows, `subprocess.Popen.send_signal` only handles `SIGTERM`, `CTRL_C_EVENT`, and `CTRL_BREAK_EVENT` (CPython 3.12 `subprocess.py` lines 1658–1665); `SIGINT` (value 2) falls through to `raise ValueError("Unsupported signal: 2")`, so the first shutdown crashes. The Windows-valid replacement, `CTRL_C_EVENT`, routes through `os.kill(pid, CTRL_C_EVENT)` (`subprocess.py` line 1661) → `GenerateConsoleCtrlEvent`, which is console-wide; because `Server.__init__` spawns the child with no `creationflags` (line 294, shared console), the generated Ctrl-C is also delivered to the benchmark process itself, whose default `SIGINT` handler raises `KeyboardInterrupt` and aborts the sweep with exit 130.
- **Trigger** — any Windows run that reaches the first `Server.stop()` (e.g., the first `probe_only` run).
- **Evidence** — (a) verified end-to-end this session on Windows Python 3.12.10: a spawned child, `Popen.send_signal(signal.SIGINT)` → `ValueError: Unsupported signal: 2`; (b) CPython 3.12 `subprocess.py` lines 1658–1665 (only `SIGTERM` / `CTRL_C_EVENT` / `CTRL_BREAK_EVENT` handled, else `ValueError`) and line 1661 (`CTRL_C_EVENT` → `os.kill`); (c) `Server.__init__` spawns with no `creationflags` (line 294), so a console Ctrl-C event reaches the benchmark itself.
- **Fix** — send `CTRL_C_EVENT` on Windows and mask the benchmark's own `SIGINT` handler while signalling and reaping the child:
  ```diff
  # benchmark_kv_stream.py:338
       def stop(self) -> None:
           if self.process is not None and self.process.poll() is None:
  -            self.process.send_signal(signal.SIGINT)
  +            terminate_signal = (
  +                signal.CTRL_C_EVENT if os.name == "nt" else signal.SIGINT
  +            )
  +            # On Windows, CTRL_C_EVENT reaches the shared console and would
  +            # interrupt this benchmark process itself; mask SIGINT while we
  +            # send it so the child stops but we keep running.
  +            previous_handler = None
  +            if os.name == "nt":
  +                previous_handler = signal.signal(signal.SIGINT, lambda *_: None)
               try:
  -                self.process.wait(timeout=8)
  -            except subprocess.TimeoutExpired:
  -                self.process.kill()
  -                self.process.wait(timeout=10)
  +                self.process.send_signal(terminate_signal)
  +                try:
  +                    self.process.wait(timeout=8)
  +                except subprocess.TimeoutExpired:
  +                    self.process.kill()
  +                    self.process.wait(timeout=10)
  +            finally:
  +                if previous_handler is not None:
  +                    signal.signal(signal.SIGINT, previous_handler)
           if not self.log_file.closed:
               self.log_file.close()
  ```




## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, all of the code and the majority of this description is written by Qwen3.8 27B, but the changes themselves are minimal and have been manually reviewed.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
