### PR TITLE
kv-stream: multi-GPU support (survive scheduler splits, one page pool per CUDA device)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2421,13 +2421,32 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_KV_OFFLOAD"));
     add_opt(common_arg(
-        {"--kv-stream-stage-mib"}, "N",
-        string_format("block-streaming KV resident + staging pool in MiB; 0 disables it (default: %u)", params.kv_stream_stage_mib),
-        [](common_params & params, int value) {
-            if (value < 0) {
-                throw std::invalid_argument("KV stream stage size must be non-negative");
+        {"--kv-stream-stage-mib"}, "N[,N...]",
+        string_format("block-streaming KV resident + staging pool in MiB; 0 disables it (default: %u). "
+            "A comma-separated list gives one pool per GPU in device order; a 0 entry keeps that GPU's "
+            "attention layers in an ordinary VRAM cache", params.kv_stream_stage_mib),
+        [](common_params & params, const std::string & value) {
+            params.kv_stream_stage_mib_dev.clear();
+            for (const auto & item : string_split<std::string>(value, ',')) {
+                if (item.empty()) {
+                    throw std::invalid_argument("KV stream stage list has an empty entry");
+                }
+                const long long parsed = std::stoll(item);
+                if (parsed < 0 || parsed > UINT32_MAX) {
+                    throw std::invalid_argument("KV stream stage size must be non-negative");
+                }
+                params.kv_stream_stage_mib_dev.push_back((uint32_t) parsed);
             }
-            params.kv_stream_stage_mib = value;
+            if (params.kv_stream_stage_mib_dev.empty()) {
+                throw std::invalid_argument("KV stream stage list is empty");
+            }
+            params.kv_stream_stage_mib = 0;
+            for (const uint32_t mib : params.kv_stream_stage_mib_dev) {
+                params.kv_stream_stage_mib = std::max(params.kv_stream_stage_mib, mib);
+            }
+            if (params.kv_stream_stage_mib_dev.size() == 1) {
+                params.kv_stream_stage_mib_dev.clear();
+            }
         }
     ).set_env("LLAMA_ARG_KV_STREAM_STAGE_MIB"));
     add_opt(common_arg(

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1752,6 +1752,8 @@ struct llama_context_params common_context_params_to_llama(const common_params &
     cparams.type_k = params.cache_type_k;
     cparams.type_v = params.cache_type_v;
     cparams.kv_stream_stage_mib = params.kv_stream_stage_mib;
+    cparams.kv_stream_stage_mib_dev   = params.kv_stream_stage_mib_dev.empty() ? nullptr : params.kv_stream_stage_mib_dev.data();
+    cparams.n_kv_stream_stage_mib_dev = (uint32_t) params.kv_stream_stage_mib_dev.size();
 
     return cparams;
 }

--- a/common/common.h
+++ b/common/common.h
@@ -587,6 +587,7 @@ struct common_params {
     ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K
     ggml_type cache_type_v = GGML_TYPE_F16; // KV cache data type for the V
     uint32_t kv_stream_stage_mib = 0;        // block-streaming staging budget, 0 = disabled [EXPERIMENTAL]
+    std::vector<uint32_t> kv_stream_stage_mib_dev; // per-device pools (MiB) in device order; empty = kv_stream_stage_mib everywhere
 
     common_conversation_mode conversation_mode = COMMON_CONVERSATION_MODE_AUTO;
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2483,6 +2483,7 @@ common_params common_base_params_to_speculative(const common_params & params) {
     // The first block-streaming implementation owns only the target cache.
     // MTP keeps its ordinary cache until both contexts can share one pool.
     result.kv_stream_stage_mib = 0;
+    result.kv_stream_stage_mib_dev.clear();
     result.n_outputs_max = params.n_parallel;
     result.n_outputs_max_per_seq = 1;
 

--- a/ggml/include/ggml-cuda.h
+++ b/ggml/include/ggml-cuda.h
@@ -118,6 +118,22 @@ GGML_BACKEND_API bool ggml_backend_cuda_kv_stream_mark_dirty_rows(
     ggml_backend_cuda_kv_stream_runtime_t runtime,
     const int64_t * rows,
     size_t count);
+// Pin a streamed attention layer's K/V storage to a fixed layer index. Call
+// once per layer, in model order, after the KV buffers are allocated; the
+// runtime then no longer infers layer identity from graph node order.
+GGML_BACKEND_API bool ggml_backend_cuda_kv_stream_register_layer(
+    ggml_backend_cuda_kv_stream_runtime_t runtime,
+    const void * k_data, size_t k_bytes,
+    const void * v_data, size_t v_bytes);
+// Bracket one forward pass. begin plans page streaming for every streamed
+// attention node of the full graph on this backend's device; end records the
+// end-of-pass timing. Between the two, graph_compute treats each graph it
+// receives as a fragment of that pass (ggml_backend_sched splits) and does
+// not re-plan. Without a bracket, graph_compute plans per graph as before.
+GGML_BACKEND_API void ggml_backend_cuda_kv_stream_forward_begin(
+    ggml_backend_t backend,
+    const struct ggml_cgraph * cgraph);
+GGML_BACKEND_API void ggml_backend_cuda_kv_stream_forward_end(ggml_backend_t backend);
 GGML_BACKEND_API struct ggml_backend_cuda_kv_stream_stats ggml_backend_cuda_kv_stream_get_stats(
     ggml_backend_cuda_kv_stream_runtime_t runtime);
 GGML_BACKEND_API bool ggml_backend_cuda_kv_stream_stage_upload(

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1432,6 +1432,12 @@ struct ggml_backend_cuda_context {
 
     int curr_stream_no = 0;
 
+    // Block KV streaming, forward-pass scoped. Set by
+    // ggml_backend_cuda_kv_stream_forward_begin/_end so graph_compute does not
+    // re-plan page streaming for every scheduler fragment of one forward pass.
+    bool kv_stream_forward_armed = false;
+    std::vector<ggml_backend_cuda_kv_stream_runtime_t> kv_stream_forward_runtimes;
+
 #ifdef USE_CUDA_GRAPH
     // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -425,6 +425,17 @@ struct ggml_cuda_kv_stream_resident_cache {
     std::unordered_map<const void *, uint32_t> layer_by_k;
     std::unordered_map<const void *, uint32_t> layer_by_data;
     std::unordered_map<const void *, void *> mirror_by_data;
+    // Explicit layer identity registered by the owner at cache creation, in
+    // model order. When present, pointer-to-layer lookups are derived from it
+    // instead of being learned lazily from graph order, so the mapping survives
+    // scheduler graph splits and buffer resets.
+    struct registered_layer {
+        const char * k_data = nullptr;
+        size_t k_bytes = 0;
+        const char * v_data = nullptr;
+        size_t v_bytes = 0;
+    };
+    std::vector<registered_layer> registered;
     std::vector<uint8_t> loaded;
     std::vector<uint8_t> dirty;
     std::vector<uint8_t> precise_dirty_tracking;
@@ -554,6 +565,45 @@ void ggml_cuda_kv_stream_resident_cache_free(ggml_cuda_kv_stream_resident_cache 
     delete cache;
 }
 
+// Drop derived pointer maps and, when explicit identity is registered,
+// rebuild the layer maps from it. Mirrors are re-derived at the next graph
+// plan because they depend on the current resident layout.
+static void kv_stream_resident_cache_rebind(ggml_cuda_kv_stream_resident_cache * cache) {
+    cache->layer_by_k.clear();
+    cache->layer_by_data.clear();
+    cache->mirror_by_data.clear();
+    for (uint32_t layer = 0; layer < cache->registered.size(); ++layer) {
+        const auto & entry = cache->registered[layer];
+        cache->layer_by_k[entry.k_data] = layer;
+        cache->layer_by_data[entry.k_data] = layer;
+        if (entry.v_data != nullptr) {
+            cache->layer_by_data[entry.v_data] = layer;
+        }
+    }
+    cache->next_layer = uint32_t(cache->registered.size());
+}
+
+bool ggml_cuda_kv_stream_resident_cache_register_layer(
+        ggml_cuda_kv_stream_resident_cache * cache,
+        const void * k_data, size_t k_bytes,
+        const void * v_data, size_t v_bytes) {
+    if (cache == nullptr || k_data == nullptr || k_bytes == 0 ||
+            cache->registered.size() >= cache->layer_count) {
+        return false;
+    }
+    for (const auto & entry : cache->registered) {
+        if (entry.k_data == k_data) {
+            return false;
+        }
+    }
+    cache->registered.push_back({
+        static_cast<const char *>(k_data), k_bytes,
+        static_cast<const char *>(v_data), v_bytes,
+    });
+    kv_stream_resident_cache_rebind(cache);
+    return true;
+}
+
 void ggml_cuda_kv_stream_resident_cache_reset(ggml_cuda_kv_stream_resident_cache * cache) {
     if (cache == nullptr) {
         return;
@@ -564,10 +614,7 @@ void ggml_cuda_kv_stream_resident_cache_reset(ggml_cuda_kv_stream_resident_cache
     cache->dirty_rows.clear();
     cache->mutable_pages.clear();
     cache->all_pages_mutable = false;
-    cache->layer_by_k.clear();
-    cache->layer_by_data.clear();
-    cache->mirror_by_data.clear();
-    cache->next_layer = 0;
+    kv_stream_resident_cache_rebind(cache);
     cache->stats = {};
 }
 
@@ -609,10 +656,7 @@ bool ggml_cuda_kv_stream_resident_cache_reconfigure(
     cache->dirty_rows.clear();
     cache->mutable_pages.clear();
     cache->all_pages_mutable = false;
-    cache->layer_by_k.clear();
-    cache->layer_by_data.clear();
-    cache->mirror_by_data.clear();
-    cache->next_layer = 0;
+    kv_stream_resident_cache_rebind(cache);
     if (scratch_changed) {
         cache->stats = {};
     }
@@ -644,10 +688,7 @@ bool ggml_cuda_kv_stream_resident_cache_repartition(
     cache->dirty.assign(cache->layer_offsets.back(), 0);
     cache->precise_dirty_tracking.assign(cache->layer_count, 0);
     cache->dirty_rows.clear();
-    cache->layer_by_k.clear();
-    cache->layer_by_data.clear();
-    cache->mirror_by_data.clear();
-    cache->next_layer = 0;
+    kv_stream_resident_cache_rebind(cache);
     cache->stats = {};
     return true;
 }
@@ -682,10 +723,7 @@ bool ggml_cuda_kv_stream_resident_cache_set_decode_layout(
     cache->dirty_rows.clear();
     cache->mutable_pages.clear();
     cache->all_pages_mutable = false;
-    cache->layer_by_k.clear();
-    cache->layer_by_data.clear();
-    cache->mirror_by_data.clear();
-    cache->next_layer = 0;
+    kv_stream_resident_cache_rebind(cache);
     cache->decode_active_pages = active_pages_per_layer;
     cache->resident_pages_per_layer = pages_per_layer;
     return true;
@@ -839,6 +877,23 @@ void ggml_cuda_kv_stream_resident_cache_mark_dirty(
 static uint32_t kv_stream_resident_layer(
         ggml_cuda_kv_stream_resident_cache * cache, const void * k_key) {
     GGML_ASSERT(cache != nullptr);
+    if (!cache->registered.empty()) {
+        const auto found = cache->layer_by_k.find(k_key);
+        if (found != cache->layer_by_k.end()) {
+            return found->second;
+        }
+        // A view into a registered layer's K storage (e.g. a non-zero stream
+        // offset) still belongs to that layer.
+        const char * key = static_cast<const char *>(k_key);
+        for (uint32_t layer = 0; layer < cache->registered.size(); ++layer) {
+            const auto & entry = cache->registered[layer];
+            if (key >= entry.k_data && key < entry.k_data + entry.k_bytes) {
+                cache->layer_by_k[k_key] = layer;
+                return layer;
+            }
+        }
+        GGML_ABORT("kv stream: K tensor %p does not belong to any registered layer", k_key);
+    }
     auto [it, inserted] = cache->layer_by_k.emplace(k_key, cache->next_layer);
     if (inserted) {
         GGML_ASSERT(cache->next_layer < cache->layer_count);
@@ -1606,10 +1661,14 @@ bool ggml_cuda_kv_stream_graph_add_attention(
         // Graphs are rebuilt across warmup, prompt chunks, and slot reuse.
         // Relearn pointer-to-layer identity once per prefill graph while the
         // resident page contents are refreshed by the local multi-token path.
+        // Only in lazy mode: identity registered by the owner is fixed and must
+        // survive the per-fragment graphs produced by ggml_backend_sched.
         if (ring->graph_resident_cache == nullptr) {
-            resident_cache->layer_by_k.clear();
-            resident_cache->layer_by_data.clear();
-            resident_cache->next_layer = 0;
+            if (resident_cache->registered.empty()) {
+                resident_cache->layer_by_k.clear();
+                resident_cache->layer_by_data.clear();
+                resident_cache->next_layer = 0;
+            }
             ring->graph_resident_cache = resident_cache;
         }
         const uint32_t resident_layer = kv_stream_resident_layer(resident_cache, K->data);

--- a/ggml/src/ggml-cuda/fattn.cuh
+++ b/ggml/src/ggml-cuda/fattn.cuh
@@ -37,6 +37,10 @@ ggml_cuda_kv_stream_resident_cache * ggml_cuda_kv_stream_resident_cache_new(
     uint32_t layer_count, uint32_t page_tokens);
 void ggml_cuda_kv_stream_resident_cache_free(ggml_cuda_kv_stream_resident_cache * cache);
 void ggml_cuda_kv_stream_resident_cache_reset(ggml_cuda_kv_stream_resident_cache * cache);
+bool ggml_cuda_kv_stream_resident_cache_register_layer(
+    ggml_cuda_kv_stream_resident_cache * cache,
+    const void * k_data, size_t k_bytes,
+    const void * v_data, size_t v_bytes);
 bool ggml_cuda_kv_stream_resident_cache_reconfigure(
     ggml_cuda_kv_stream_resident_cache * cache, size_t scratch_bytes,
     uint32_t active_pages_per_layer);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1425,6 +1425,9 @@ struct ggml_backend_cuda_kv_stream_runtime {
 
     std::atomic<uint32_t> references{1};
     ggml_backend_buffer_type buffer_type{};
+    // Per-device name: llama keys its KV contexts by buffer-type name, so two
+    // runtimes (one per GPU) must not share one.
+    std::string buffer_type_name;
 };
 
 struct ggml_backend_cuda_kv_stream_buffer_context {
@@ -1446,8 +1449,11 @@ static void ggml_backend_cuda_kv_stream_runtime_release(
 }
 
 static const char * ggml_backend_cuda_kv_stream_buffer_type_name(ggml_backend_buffer_type_t buft) {
-    GGML_UNUSED(buft);
-    return GGML_CUDA_NAME "_KV_Stream_Host";
+    auto * runtime = static_cast<ggml_backend_cuda_kv_stream_runtime_t>(buft->context);
+    if (runtime == nullptr || runtime->buffer_type_name.empty()) {
+        return GGML_CUDA_NAME "_KV_Stream_Host";
+    }
+    return runtime->buffer_type_name.c_str();
 }
 
 static bool ggml_backend_buft_is_cuda_kv_stream(ggml_backend_buffer_type_t buft) {
@@ -1636,6 +1642,7 @@ ggml_backend_cuda_kv_stream_runtime_t ggml_backend_cuda_kv_stream_runtime_new(
     GGML_ASSERT(ggml_cuda_kv_stream_transfer_ring_set_active_slots(
         runtime->transfer_ring, runtime->stage_slots));
 
+    runtime->buffer_type_name = std::string(GGML_CUDA_NAME) + std::to_string(params.device) + "_KV_Stream_Host";
     runtime->buffer_type = {
         /* .iface   = */ ggml_backend_cuda_kv_stream_buffer_type_interface,
         /* .device  = */ ggml_backend_reg_dev_get(ggml_backend_cuda_reg(), params.device),

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1892,8 +1892,11 @@ static void ggml_cuda_kv_stream_fattn(
         ctx, dst, runtime->transfer_ring, runtime->resident_cache);
 }
 
+// Plan page streaming for every streamed attention node of cgraph on the
+// runtimes owned by `device` (-1 = any device). Must see the whole forward
+// pass: the plan assigns per-forward deadlines and ring slots.
 static std::vector<ggml_backend_cuda_kv_stream_runtime_t> ggml_cuda_kv_stream_prepare_graph(
-        const ggml_cgraph * cgraph, cudaStream_t compute_stream) {
+        const ggml_cgraph * cgraph, cudaStream_t compute_stream, int device = -1) {
     std::vector<ggml_backend_cuda_kv_stream_runtime_t> runtimes;
     std::unordered_set<ggml_backend_cuda_kv_stream_runtime_t> seen;
 
@@ -1903,7 +1906,8 @@ static std::vector<ggml_backend_cuda_kv_stream_runtime_t> ggml_cuda_kv_stream_pr
             continue;
         }
         auto * runtime = ggml_cuda_kv_stream_runtime_from_tensor(node->src[1]);
-        if (runtime != nullptr && runtime == ggml_cuda_kv_stream_runtime_from_tensor(node->src[2]) &&
+        if (runtime != nullptr && (device < 0 || runtime->device == device) &&
+                runtime == ggml_cuda_kv_stream_runtime_from_tensor(node->src[2]) &&
                 seen.insert(runtime).second) {
             ggml_cuda_kv_stream_graph_begin(runtime->transfer_ring);
             runtimes.push_back(runtime);
@@ -1916,6 +1920,9 @@ static std::vector<ggml_backend_cuda_kv_stream_runtime_t> ggml_cuda_kv_stream_pr
             continue;
         }
         auto * runtime = ggml_cuda_kv_stream_runtime_from_tensor(node->src[1]);
+        if (seen.find(runtime) == seen.end()) {
+            continue;
+        }
         (void) ggml_cuda_kv_stream_graph_add_attention(
             runtime->transfer_ring, runtime->resident_cache, node);
     }
@@ -1924,6 +1931,50 @@ static std::vector<ggml_backend_cuda_kv_stream_runtime_t> ggml_cuda_kv_stream_pr
         ggml_cuda_kv_stream_graph_finalize(runtime->transfer_ring, compute_stream);
     }
     return runtimes;
+}
+
+// Forward-pass scoped planning. The scheduler hands the CUDA backend one
+// graph per split; when weights live on another backend a single forward
+// pass arrives as many fragments. The owner (llama-context) brackets the
+// whole pass with forward_begin/forward_end so planning and the end-of-pass
+// timing run once, while fragments only execute their nodes. Without a
+// bracket, graph_compute plans per graph as before.
+void ggml_backend_cuda_kv_stream_forward_begin(ggml_backend_t backend, const struct ggml_cgraph * cgraph) {
+    if (backend == nullptr || cgraph == nullptr || !ggml_backend_is_cuda(backend)) {
+        return;
+    }
+    auto * cuda_ctx = static_cast<ggml_backend_cuda_context *>(backend->context);
+    GGML_ASSERT(!cuda_ctx->kv_stream_forward_armed && "kv stream forward_begin without matching forward_end");
+    ggml_cuda_set_device(cuda_ctx->device);
+    cuda_ctx->kv_stream_forward_runtimes = ggml_cuda_kv_stream_prepare_graph(cgraph, cuda_ctx->stream(), cuda_ctx->device);
+    cuda_ctx->kv_stream_forward_armed = true;
+}
+
+void ggml_backend_cuda_kv_stream_forward_end(ggml_backend_t backend) {
+    if (backend == nullptr || !ggml_backend_is_cuda(backend)) {
+        return;
+    }
+    auto * cuda_ctx = static_cast<ggml_backend_cuda_context *>(backend->context);
+    if (!cuda_ctx->kv_stream_forward_armed) {
+        return;
+    }
+    ggml_cuda_set_device(cuda_ctx->device);
+    for (auto * runtime : cuda_ctx->kv_stream_forward_runtimes) {
+        ggml_cuda_kv_stream_graph_end(runtime->transfer_ring, cuda_ctx->stream());
+    }
+    cuda_ctx->kv_stream_forward_runtimes.clear();
+    cuda_ctx->kv_stream_forward_armed = false;
+}
+
+bool ggml_backend_cuda_kv_stream_register_layer(
+        ggml_backend_cuda_kv_stream_runtime_t runtime,
+        const void * k_data, size_t k_bytes,
+        const void * v_data, size_t v_bytes) {
+    if (runtime == nullptr || runtime->resident_cache == nullptr) {
+        return false;
+    }
+    return ggml_cuda_kv_stream_resident_cache_register_layer(
+        runtime->resident_cache, k_data, k_bytes, v_data, v_bytes);
 }
 
 //static bool ggml_backend_buffer_is_cuda_host(ggml_backend_buffer_t buffer) {
@@ -5019,9 +5070,13 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
             }
 
             // The graph order is now final. Build one shared deadline queue
-            // per KV runtime before issuing any attention work.
-            const auto kv_stream_runtimes = ggml_cuda_kv_stream_prepare_graph(
-                cgraph, cuda_ctx->stream());
+            // per KV runtime before issuing any attention work, unless the
+            // owner already planned the whole forward pass (see
+            // ggml_backend_cuda_kv_stream_forward_begin), in which case this
+            // graph is one fragment of it and must not reset the plan.
+            const auto kv_stream_runtimes = cuda_ctx->kv_stream_forward_armed ?
+                std::vector<ggml_backend_cuda_kv_stream_runtime_t>{} :
+                ggml_cuda_kv_stream_prepare_graph(cgraph, cuda_ctx->stream(), cuda_ctx->device);
 
             for (int i = 0; i < cgraph->n_nodes; i++) {
                 ggml_tensor * node = cgraph->nodes[i];
@@ -6630,6 +6685,20 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
             return ggml_backend_cuda_kv_stream_mark_dirty_rows(
                 static_cast<ggml_backend_cuda_kv_stream_runtime_t>(runtime), rows, count);
         };
+    }
+    if (strcmp(name, "ggml_backend_cuda_kv_stream_register_layer") == 0) {
+        return (void *) +[](void * runtime, const void * k_data, size_t k_bytes,
+                const void * v_data, size_t v_bytes) -> bool {
+            return ggml_backend_cuda_kv_stream_register_layer(
+                static_cast<ggml_backend_cuda_kv_stream_runtime_t>(runtime),
+                k_data, k_bytes, v_data, v_bytes);
+        };
+    }
+    if (strcmp(name, "ggml_backend_cuda_kv_stream_forward_begin") == 0) {
+        return (void *) ggml_backend_cuda_kv_stream_forward_begin;
+    }
+    if (strcmp(name, "ggml_backend_cuda_kv_stream_forward_end") == 0) {
+        return (void *) ggml_backend_cuda_kv_stream_forward_end;
     }
     if (strcmp(name, "ggml_backend_get_features") == 0) {
         return (void *)ggml_backend_cuda_get_features;

--- a/include/llama.h
+++ b/include/llama.h
@@ -389,6 +389,11 @@ extern "C" {
         enum ggml_type type_k; // data type for K cache [EXPERIMENTAL]
         enum ggml_type type_v; // data type for V cache [EXPERIMENTAL]
         uint32_t kv_stream_stage_mib; // block-streaming staging budget, 0 = disabled [EXPERIMENTAL]
+        // optional per-device block-streaming pools (MiB), one entry per model device in
+        // device order; NULL = kv_stream_stage_mib on every device; an entry of 0 keeps
+        // that device's attention layers in an ordinary VRAM cache [EXPERIMENTAL]
+        const uint32_t * kv_stream_stage_mib_dev;
+        uint32_t         n_kv_stream_stage_mib_dev;
 
         // Abort callback
         // if it returns true, execution of llama_decode() will be aborted

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -368,6 +368,17 @@ llama_context::llama_context(
                 if (ggml_backend_set_n_threads_fn) {
                     set_n_threads_fns.emplace_back(backend.get(), ggml_backend_set_n_threads_fn);
                 }
+                if (cparams.kv_stream_stage_mib != 0) {
+                    kv_stream_forward_hook hook;
+                    hook.backend = backend.get();
+                    hook.begin_fn = (decltype(hook.begin_fn)) ggml_backend_reg_get_proc_address(
+                        reg, "ggml_backend_cuda_kv_stream_forward_begin");
+                    hook.end_fn = (decltype(hook.end_fn)) ggml_backend_reg_get_proc_address(
+                        reg, "ggml_backend_cuda_kv_stream_forward_end");
+                    if (hook.begin_fn != nullptr && hook.end_fn != nullptr) {
+                        kv_stream_forward_hooks.push_back(hook);
+                    }
+                }
             }
         }
 
@@ -2556,9 +2567,17 @@ ggml_status llama_context::graph_compute(
         set_n_threads_fn.second(set_n_threads_fn.first, n_threads);
     }
 
+    for (const auto & hook : kv_stream_forward_hooks) {
+        hook.begin_fn(hook.backend, gf);
+    }
+
     auto status = ggml_backend_sched_graph_compute_async(sched.get(), gf);
     if (status != GGML_STATUS_SUCCESS) {
         LLAMA_LOG_ERROR("%s: ggml_backend_sched_graph_compute_async failed with error %d\n", __func__, status);
+    }
+
+    for (const auto & hook : kv_stream_forward_hooks) {
+        hook.end_fn(hook.backend);
     }
 
     // fprintf(stderr, "splits: %d\n", ggml_backend_sched_get_n_splits(sched));

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -15,6 +15,7 @@
 #include "llama-sampler.h"
 #include "llama.h"
 
+#include <algorithm>
 #include <cinttypes>
 #include <cmath>
 #include <cstring>
@@ -121,6 +122,15 @@ llama_context::llama_context(
     cparams.embeddings_nextn_masked = false;
     cparams.offload_kqv             = params.offload_kqv;
     cparams.kv_stream_stage_mib     = params.kv_stream_stage_mib;
+    cparams.kv_stream_stage_mib_dev.clear();
+    if (params.kv_stream_stage_mib_dev != nullptr && params.n_kv_stream_stage_mib_dev > 0) {
+        cparams.kv_stream_stage_mib_dev.assign(
+            params.kv_stream_stage_mib_dev, params.kv_stream_stage_mib_dev + params.n_kv_stream_stage_mib_dev);
+        cparams.kv_stream_stage_mib = 0;
+        for (const uint32_t mib : cparams.kv_stream_stage_mib_dev) {
+            cparams.kv_stream_stage_mib = std::max(cparams.kv_stream_stage_mib, mib);
+        }
+    }
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
 
@@ -398,7 +408,22 @@ llama_context::llama_context(
 
     // init the memory module
     if (!hparams.vocab_only) {
-        const uint64_t kv_stream_stage_bytes = uint64_t(cparams.kv_stream_stage_mib)*1024ULL*1024ULL;
+        // one pool budget per model device (device order); a single value applies everywhere
+        std::vector<uint64_t> kv_stream_stage_bytes_dev(model.devices.size(), 0);
+        uint64_t kv_stream_stage_bytes = 0;
+        for (size_t i = 0; i < model.devices.size(); ++i) {
+            const uint32_t mib = cparams.kv_stream_stage_mib_dev.empty() ? cparams.kv_stream_stage_mib :
+                (i < cparams.kv_stream_stage_mib_dev.size() ? cparams.kv_stream_stage_mib_dev[i] : 0);
+            kv_stream_stage_bytes_dev[i] = uint64_t(mib)*1024ULL*1024ULL;
+            kv_stream_stage_bytes = std::max(kv_stream_stage_bytes, kv_stream_stage_bytes_dev[i]);
+        }
+        if (cparams.kv_stream_stage_mib_dev.size() > model.devices.size()) {
+            LLAMA_LOG_WARN("%s: --kv-stream-stage-mib lists %zu pools but the model uses %zu devices; extra entries ignored\n",
+                    __func__, cparams.kv_stream_stage_mib_dev.size(), model.devices.size());
+        }
+        if (cparams.kv_stream_stage_mib != 0 && kv_stream_stage_bytes == 0) {
+            throw std::runtime_error("block KV streaming requires at least one GPU device");
+        }
         uint64_t kv_stream_minimum_stage_bytes = 0;
         if (kv_stream_stage_bytes != 0 && model.arch == LLM_ARCH_QWEN35) {
             for (uint32_t il = 0; il < hparams.n_layer(); ++il) {
@@ -425,14 +450,27 @@ llama_context::llama_context(
             throw std::runtime_error(stream_validation.error);
         }
         if (stream_validation.enabled) {
-            LLAMA_LOG_INFO("%s: experimental block KV streaming enabled, pool = %.2f MiB\n",
-                    __func__, kv_stream_stage_bytes/1024.0/1024.0);
+            for (size_t i = 0; i < model.devices.size(); ++i) {
+                if (kv_stream_stage_bytes_dev[i] == 0) {
+                    continue;
+                }
+                llama_kv_stream_config dev_config = stream_config;
+                dev_config.stage_bytes = kv_stream_stage_bytes_dev[i];
+                const auto dev_validation = llama_kv_stream_config_validate(dev_config);
+                if (!dev_validation.valid) {
+                    throw std::runtime_error(std::string(ggml_backend_dev_name(model.devices[i].dev)) + ": " + dev_validation.error);
+                }
+                LLAMA_LOG_INFO("%s: experimental block KV streaming enabled on %s, pool = %.2f MiB\n",
+                        __func__, ggml_backend_dev_name(model.devices[i].dev), kv_stream_stage_bytes_dev[i]/1024.0/1024.0);
+            }
+        } else {
+            kv_stream_stage_bytes_dev.clear();
         }
 
         llama_memory_params params_mem = {
             /*.type_k                =*/ params.type_k,
             /*.type_v                =*/ params.type_v,
-            /*.kv_stream_stage_bytes =*/ kv_stream_stage_bytes,
+            /*.kv_stream_stage_bytes =*/ kv_stream_stage_bytes_dev,
             /*.swa_full              =*/ params.swa_full,
             /*.ctx_type              =*/ cparams.ctx_type,
             /*.mem_other             =*/ llama_get_memory(cparams.ctx_other),
@@ -3709,6 +3747,8 @@ llama_context_params llama_context_default_params() {
         /*.type_k                      =*/ GGML_TYPE_F16,
         /*.type_v                      =*/ GGML_TYPE_F16,
         /*.kv_stream_stage_mib         =*/ 0,
+        /*.kv_stream_stage_mib_dev     =*/ nullptr,
+        /*.n_kv_stream_stage_mib_dev   =*/ 0,
         /*.abort_callback              =*/ nullptr,
         /*.abort_callback_data         =*/ nullptr,
         /*.embeddings                  =*/ false,

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -359,6 +359,16 @@ private:
 
     std::vector<std::pair<ggml_backend_t, ggml_backend_set_n_threads_t>> set_n_threads_fns;
 
+    // Block KV streaming: bracket each forward pass so the CUDA backend plans
+    // page streaming once for the whole graph instead of once per scheduler
+    // split (which breaks when weights are placed on another backend).
+    struct kv_stream_forward_hook {
+        ggml_backend_t backend = nullptr;
+        void (*begin_fn)(ggml_backend_t, const ggml_cgraph *) = nullptr;
+        void (*end_fn)(ggml_backend_t) = nullptr;
+    };
+    std::vector<kv_stream_forward_hook> kv_stream_forward_hooks;
+
     // pointers and buffer types used for the compute buffer of each backend
     std::vector<ggml_backend_t>             backend_ptrs;
     std::vector<ggml_backend_buffer_type_t> backend_buft;

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -54,7 +54,8 @@ struct llama_cparams {
     bool kv_unified;
     bool pipeline_parallel;
 
-    uint32_t kv_stream_stage_mib;
+    uint32_t kv_stream_stage_mib;                  // largest per-device pool, 0 = streaming off
+    std::vector<uint32_t> kv_stream_stage_mib_dev; // per model device (device order); empty = kv_stream_stage_mib everywhere
 
     std::vector<bool> embeddings_layer_inp; // [n_layer()] extract input embeddings for layer
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -423,6 +423,39 @@ llama_kv_cache::llama_kv_cache(
         ctxs_bufs.emplace_back(std::move(ctx), buf);
     }
 
+    // Give the streaming runtime a fixed layer identity (model order) for
+    // each attention layer's K/V storage, so it no longer has to infer it
+    // from the order attention nodes appear in a graph.
+    if (kv_stream_runtime.runtime != nullptr && !hparams.no_alloc) {
+        using register_layer_fn_t = bool (*)(void *, const void *, size_t, const void *, size_t);
+        auto * register_layer_fn = (register_layer_fn_t) ggml_backend_reg_get_proc_address(
+            ggml_backend_dev_backend_reg(kv_stream_dev), "ggml_backend_cuda_kv_stream_register_layer");
+        if (register_layer_fn == nullptr) {
+            throw std::runtime_error("block KV streaming requires ggml_backend_cuda_kv_stream_register_layer");
+        }
+        uint32_t registered = 0;
+        for (const auto & layer : layers) {
+            if (layer.k == nullptr || layer.k->buffer == nullptr || ggml_backend_buffer_get_type(layer.k->buffer) != kv_stream_buft) {
+                continue;
+            }
+            const bool ok = register_layer_fn(
+                kv_stream_runtime.runtime,
+                layer.k->data, ggml_nbytes(layer.k),
+                layer.v != nullptr ? layer.v->data : nullptr,
+                layer.v != nullptr ? ggml_nbytes(layer.v) : 0);
+            if (!ok) {
+                // shared layers reuse another layer's tensors: not an error
+                continue;
+            }
+            ++registered;
+        }
+        LLAMA_LOG_INFO("%s: block KV streaming: registered %u/%u attention layers on %s\n",
+                __func__, registered, kv_stream_layer_count, ggml_backend_dev_name(kv_stream_dev));
+        if (registered == 0) {
+            throw std::runtime_error("block KV streaming registered no attention layers");
+        }
+    }
+
     {
         const size_t memory_size_k = size_k_bytes();
         const size_t memory_size_v = size_v_bytes();

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -82,7 +82,7 @@ llama_kv_cache::llama_kv_cache(
     const  layer_reuse_cb & reuse,
     const  layer_share_cb & share,
              const char *   name_tag,
-                     size_t kv_stream_stage_bytes) :
+    const std::vector<uint64_t> & kv_stream_stage_bytes) :
     model(model), hparams(hparams), v_trans(v_trans),
     n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa), swa_type(swa_type),
     other(static_cast<llama_kv_cache *>(mem_other)),
@@ -165,16 +165,137 @@ llama_kv_cache::llama_kv_cache(
 
     const bool is_mla = hparams.is_mla();
 
-    ggml_backend_dev_t kv_stream_dev = nullptr;
-    ggml_backend_buffer_type_t kv_stream_buft = nullptr;
-    uint32_t kv_stream_layer_count = 0;
-    if (kv_stream_stage_bytes != 0) {
+    // Block KV streaming: one runtime (VRAM page pool + pinned host storage)
+    // per CUDA device that hosts attention layers and has a nonzero pool
+    // budget. Budgets are indexed by model device order (-ts order).
+    auto kv_stream_stage_for_dev = [&](ggml_backend_dev_t dev) -> uint64_t {
+        for (size_t i = 0; i < model.devices.size() && i < kv_stream_stage_bytes.size(); ++i) {
+            if (model.devices[i].dev == dev) {
+                return kv_stream_stage_bytes[i];
+            }
+        }
+        return 0;
+    };
+    std::map<ggml_backend_dev_t, uint32_t> kv_stream_layers_by_dev;
+    if (offload && !hparams.no_alloc) {
         for (uint32_t il = 0; il < n_layer; ++il) {
             if (hparams.has_kv(il) && (!filter || filter(il))) {
-                ++kv_stream_layer_count;
+                ggml_backend_dev_t dev = model.dev_layer(il);
+                if (kv_stream_stage_for_dev(dev) != 0) {
+                    ++kv_stream_layers_by_dev[dev];
+                }
             }
         }
     }
+    const char * ctor_name = __func__;
+    auto kv_stream_owner_for_dev = [&](ggml_backend_dev_t dev, uint32_t il) -> kv_stream_runtime_owner * {
+        for (auto & owner : kv_stream_runtimes) {
+            if (owner->dev == dev) {
+                return owner.get();
+            }
+        }
+        const uint64_t stage_bytes = kv_stream_stage_for_dev(dev);
+        const uint32_t layer_count = kv_stream_layers_by_dev[dev];
+        GGML_ASSERT(stage_bytes != 0 && layer_count != 0);
+        auto owner = std::make_unique<kv_stream_runtime_owner>();
+        ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
+        using type_pair_supported_fn_t = bool (*)(ggml_type, ggml_type);
+        using page_bytes_fn_t = bool (*)(
+            ggml_type, ggml_type, uint32_t, uint32_t, uint32_t, uint32_t, size_t *);
+        using runtime_new_fn_t = void * (*)(
+            ggml_backend_dev_t, size_t, size_t, size_t, uint32_t);
+        using runtime_free_fn_t = void (*)(void *);
+        using buffer_type_fn_t = ggml_backend_buffer_type_t (*)(void *);
+        using feedback_fn_t = kv_stream_runtime_owner::feedback_fn_t;
+        using span_feedback_fn_t = kv_stream_runtime_owner::span_feedback_fn_t;
+        using reconfigure_fn_t = kv_stream_runtime_owner::reconfigure_fn_t;
+        using repartition_fn_t = kv_stream_runtime_owner::repartition_fn_t;
+        using decode_layout_fn_t = kv_stream_runtime_owner::decode_layout_fn_t;
+        using mark_dirty_rows_fn_t = kv_stream_runtime_owner::mark_dirty_rows_fn_t;
+
+        auto * type_pair_supported_fn = (type_pair_supported_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_type_pair_supported");
+        auto * page_bytes_fn = (page_bytes_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_page_bytes");
+        auto * workspace_bytes_fn = (page_bytes_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_workspace_bytes");
+        auto * runtime_new_fn = (runtime_new_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_runtime_new_for_device");
+        auto * runtime_free_fn = (runtime_free_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_runtime_free");
+        auto * buffer_type_fn = (buffer_type_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_buffer_type");
+        auto * feedback_fn = (feedback_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_feedback");
+        auto * span_feedback_fn = (span_feedback_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_observe_decode_latency");
+        auto * reconfigure_fn = (reconfigure_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_reconfigure");
+        auto * repartition_fn = (repartition_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_repartition");
+        auto * decode_layout_fn = (decode_layout_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_set_decode_layout");
+        auto * mark_dirty_rows_fn = (mark_dirty_rows_fn_t) ggml_backend_reg_get_proc_address(
+            reg, "ggml_backend_cuda_kv_stream_mark_dirty_rows");
+
+        if (type_pair_supported_fn == nullptr || page_bytes_fn == nullptr ||
+                workspace_bytes_fn == nullptr || runtime_new_fn == nullptr ||
+                runtime_free_fn == nullptr ||
+                buffer_type_fn == nullptr || feedback_fn == nullptr ||
+                span_feedback_fn == nullptr ||
+                repartition_fn == nullptr || decode_layout_fn == nullptr ||
+                reconfigure_fn == nullptr ||
+                mark_dirty_rows_fn == nullptr) {
+            throw std::runtime_error("block KV streaming requires the CUDA backend");
+        }
+
+        if (!type_pair_supported_fn(type_k, type_v)) {
+            throw std::runtime_error(
+                "block KV streaming does not support K " + std::string(ggml_type_name(type_k)) +
+                " and V " + ggml_type_name(type_v));
+        }
+
+        size_t page_bytes = 0;
+        if (!page_bytes_fn(
+                type_k, type_v,
+                hparams.n_embd_head_k(il), hparams.n_embd_head_v(il), hparams.n_head_kv(il),
+                256, &page_bytes)) {
+            throw std::runtime_error("invalid block KV streaming page geometry");
+        }
+        size_t conversion_bytes = 0;
+        if (!workspace_bytes_fn(
+                type_k, type_v,
+                hparams.n_embd_head_k(il), hparams.n_embd_head_v(il), hparams.n_head_kv(il),
+                256, &conversion_bytes)) {
+            throw std::runtime_error("invalid block KV streaming conversion workspace geometry");
+        }
+        owner->runtime = runtime_new_fn(
+            dev, stage_bytes, page_bytes, conversion_bytes, layer_count);
+        owner->free_fn = runtime_free_fn;
+        owner->feedback_fn = feedback_fn;
+        owner->span_feedback_fn = span_feedback_fn;
+        owner->repartition_fn = repartition_fn;
+        owner->reconfigure_fn = reconfigure_fn;
+        owner->decode_layout_fn = decode_layout_fn;
+        owner->mark_dirty_rows_fn = mark_dirty_rows_fn;
+        owner->layer_count = layer_count;
+        if (owner->runtime == nullptr) {
+            throw std::runtime_error(
+                "failed to create CUDA block KV streaming runtime on " + std::string(ggml_backend_dev_name(dev)) +
+                " (pool " + std::to_string(stage_bytes/1024/1024) + " MiB for " + std::to_string(layer_count) +
+                " attention layers: too small, or out of VRAM)");
+        }
+
+        owner->buft = buffer_type_fn(owner->runtime);
+        if (owner->buft == nullptr) {
+            throw std::runtime_error("failed to obtain CUDA block KV streaming buffer type");
+        }
+        owner->dev = dev;
+        LLAMA_LOG_INFO("%s: block KV streaming: pool %.2f MiB on %s for %u attention layers\n",
+                ctor_name, stage_bytes/1024.0/1024.0, ggml_backend_dev_name(dev), layer_count);
+        kv_stream_runtimes.push_back(std::move(owner));
+        return kv_stream_runtimes.back().get();
+    };
 
     for (uint32_t il = 0; il < n_layer; il++) {
         if (!hparams.has_kv(il)) {
@@ -233,105 +354,9 @@ llama_kv_cache::llama_kv_cache(
 
             dev_name = ggml_backend_dev_name(dev);
 
-            if (kv_stream_stage_bytes != 0 && !hparams.no_alloc) {
-                if (kv_stream_dev != nullptr && kv_stream_dev != dev) {
-                    throw std::runtime_error("block KV streaming requires every attention layer on one CUDA device");
-                }
-
-                if (kv_stream_runtime.runtime == nullptr) {
-                    ggml_backend_reg_t reg = ggml_backend_dev_backend_reg(dev);
-                    using type_pair_supported_fn_t = bool (*)(ggml_type, ggml_type);
-                    using page_bytes_fn_t = bool (*)(
-                        ggml_type, ggml_type, uint32_t, uint32_t, uint32_t, uint32_t, size_t *);
-                    using runtime_new_fn_t = void * (*)(
-                        ggml_backend_dev_t, size_t, size_t, size_t, uint32_t);
-                    using runtime_free_fn_t = void (*)(void *);
-                    using buffer_type_fn_t = ggml_backend_buffer_type_t (*)(void *);
-                    using feedback_fn_t = kv_stream_runtime_owner::feedback_fn_t;
-                    using span_feedback_fn_t = kv_stream_runtime_owner::span_feedback_fn_t;
-                    using reconfigure_fn_t = kv_stream_runtime_owner::reconfigure_fn_t;
-                    using repartition_fn_t = kv_stream_runtime_owner::repartition_fn_t;
-                    using decode_layout_fn_t = kv_stream_runtime_owner::decode_layout_fn_t;
-                    using mark_dirty_rows_fn_t = kv_stream_runtime_owner::mark_dirty_rows_fn_t;
-
-                    auto * type_pair_supported_fn = (type_pair_supported_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_type_pair_supported");
-                    auto * page_bytes_fn = (page_bytes_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_page_bytes");
-                    auto * workspace_bytes_fn = (page_bytes_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_workspace_bytes");
-                    auto * runtime_new_fn = (runtime_new_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_runtime_new_for_device");
-                    auto * runtime_free_fn = (runtime_free_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_runtime_free");
-                    auto * buffer_type_fn = (buffer_type_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_buffer_type");
-                    auto * feedback_fn = (feedback_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_feedback");
-                    auto * span_feedback_fn = (span_feedback_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_observe_decode_latency");
-                    auto * reconfigure_fn = (reconfigure_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_reconfigure");
-                    auto * repartition_fn = (repartition_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_repartition");
-                    auto * decode_layout_fn = (decode_layout_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_set_decode_layout");
-                    auto * mark_dirty_rows_fn = (mark_dirty_rows_fn_t) ggml_backend_reg_get_proc_address(
-                        reg, "ggml_backend_cuda_kv_stream_mark_dirty_rows");
-
-                    if (type_pair_supported_fn == nullptr || page_bytes_fn == nullptr ||
-                            workspace_bytes_fn == nullptr || runtime_new_fn == nullptr ||
-                            runtime_free_fn == nullptr ||
-                            buffer_type_fn == nullptr || feedback_fn == nullptr ||
-                            span_feedback_fn == nullptr ||
-                            repartition_fn == nullptr || decode_layout_fn == nullptr ||
-                            reconfigure_fn == nullptr ||
-                            mark_dirty_rows_fn == nullptr) {
-                        throw std::runtime_error("block KV streaming requires the CUDA backend");
-                    }
-
-                    if (!type_pair_supported_fn(type_k, type_v)) {
-                        throw std::runtime_error(
-                            "block KV streaming does not support K " + std::string(ggml_type_name(type_k)) +
-                            " and V " + ggml_type_name(type_v));
-                    }
-
-                    size_t page_bytes = 0;
-                    if (!page_bytes_fn(
-                            type_k, type_v,
-                            hparams.n_embd_head_k(il), hparams.n_embd_head_v(il), hparams.n_head_kv(il),
-                            256, &page_bytes)) {
-                        throw std::runtime_error("invalid block KV streaming page geometry");
-                    }
-                    size_t conversion_bytes = 0;
-                    if (!workspace_bytes_fn(
-                            type_k, type_v,
-                            hparams.n_embd_head_k(il), hparams.n_embd_head_v(il), hparams.n_head_kv(il),
-                            256, &conversion_bytes)) {
-                        throw std::runtime_error("invalid block KV streaming conversion workspace geometry");
-                    }
-                    kv_stream_runtime.runtime = runtime_new_fn(
-                        dev, kv_stream_stage_bytes, page_bytes, conversion_bytes, kv_stream_layer_count);
-                    kv_stream_runtime.free_fn = runtime_free_fn;
-                    kv_stream_runtime.feedback_fn = feedback_fn;
-                    kv_stream_runtime.span_feedback_fn = span_feedback_fn;
-                    kv_stream_runtime.repartition_fn = repartition_fn;
-                    kv_stream_runtime.reconfigure_fn = reconfigure_fn;
-                    kv_stream_runtime.decode_layout_fn = decode_layout_fn;
-                    kv_stream_runtime.mark_dirty_rows_fn = mark_dirty_rows_fn;
-                    kv_stream_runtime.layer_count = kv_stream_layer_count;
-                    if (kv_stream_runtime.runtime == nullptr) {
-                        throw std::runtime_error("failed to create CUDA block KV streaming runtime");
-                    }
-
-                    kv_stream_buft = buffer_type_fn(kv_stream_runtime.runtime);
-                    if (kv_stream_buft == nullptr) {
-                        throw std::runtime_error("failed to obtain CUDA block KV streaming buffer type");
-                    }
-                    kv_stream_dev = dev;
-                }
-
-                buft = kv_stream_buft;
+            if (!hparams.no_alloc && kv_stream_stage_for_dev(dev) != 0) {
+                kv_stream_runtime_owner * owner = kv_stream_owner_for_dev(dev, il);
+                buft = owner->buft;
                 dev_name = ggml_backend_buft_name(buft);
             }
         }
@@ -407,7 +432,7 @@ llama_kv_cache::llama_kv_cache(
         LLAMA_LOG_INFO("%s: %10s KV buffer size = %8.2f MiB\n", __func__, ggml_backend_buffer_name(buf), ggml_backend_buffer_get_size(buf)/1024.0/1024.0);
 
         ggml_backend_buffer_clear(buf, 0);
-        if (kv_stream_stage_bytes == 0 && getenv("GGML_CUDA_PREFER_KV_HOST") != nullptr && ggml_backend_buffer_get_size(buf) > 0) {
+        if (kv_stream_runtimes.empty() && getenv("GGML_CUDA_PREFER_KV_HOST") != nullptr && ggml_backend_buffer_get_size(buf) > 0) {
             ggml_backend_dev_t dev_kv = ggml_backend_buft_get_device(buft);
             if (dev_kv != nullptr) {
                 ggml_backend_reg_t reg_kv = ggml_backend_dev_backend_reg(dev_kv);
@@ -426,20 +451,24 @@ llama_kv_cache::llama_kv_cache(
     // Give the streaming runtime a fixed layer identity (model order) for
     // each attention layer's K/V storage, so it no longer has to infer it
     // from the order attention nodes appear in a graph.
-    if (kv_stream_runtime.runtime != nullptr && !hparams.no_alloc) {
+    for (auto & owner_ptr : kv_stream_runtimes) {
+        auto & owner = *owner_ptr;
+        if (owner.runtime == nullptr || hparams.no_alloc) {
+            continue;
+        }
         using register_layer_fn_t = bool (*)(void *, const void *, size_t, const void *, size_t);
         auto * register_layer_fn = (register_layer_fn_t) ggml_backend_reg_get_proc_address(
-            ggml_backend_dev_backend_reg(kv_stream_dev), "ggml_backend_cuda_kv_stream_register_layer");
+            ggml_backend_dev_backend_reg(owner.dev), "ggml_backend_cuda_kv_stream_register_layer");
         if (register_layer_fn == nullptr) {
             throw std::runtime_error("block KV streaming requires ggml_backend_cuda_kv_stream_register_layer");
         }
         uint32_t registered = 0;
         for (const auto & layer : layers) {
-            if (layer.k == nullptr || layer.k->buffer == nullptr || ggml_backend_buffer_get_type(layer.k->buffer) != kv_stream_buft) {
+            if (layer.k == nullptr || layer.k->buffer == nullptr || ggml_backend_buffer_get_type(layer.k->buffer) != owner.buft) {
                 continue;
             }
             const bool ok = register_layer_fn(
-                kv_stream_runtime.runtime,
+                owner.runtime,
                 layer.k->data, ggml_nbytes(layer.k),
                 layer.v != nullptr ? layer.v->data : nullptr,
                 layer.v != nullptr ? ggml_nbytes(layer.v) : 0);
@@ -450,7 +479,7 @@ llama_kv_cache::llama_kv_cache(
             ++registered;
         }
         LLAMA_LOG_INFO("%s: block KV streaming: registered %u/%u attention layers on %s\n",
-                __func__, registered, kv_stream_layer_count, ggml_backend_dev_name(kv_stream_dev));
+                __func__, registered, owner.layer_count, ggml_backend_dev_name(owner.dev));
         if (registered == 0) {
             throw std::runtime_error("block KV streaming registered no attention layers");
         }
@@ -1369,7 +1398,14 @@ uint32_t llama_kv_cache::get_n_stream() const {
 }
 
 bool llama_kv_cache::kv_stream_adapt(uint32_t active_tokens, uint32_t query_tokens) {
-    auto & owner = kv_stream_runtime;
+    bool changed = false;
+    for (auto & owner : kv_stream_runtimes) {
+        changed = kv_stream_adapt_owner(*owner, active_tokens, query_tokens) || changed;
+    }
+    return changed;
+}
+
+bool llama_kv_cache::kv_stream_adapt_owner(kv_stream_runtime_owner & owner, uint32_t active_tokens, uint32_t query_tokens) {
     if (owner.runtime == nullptr || owner.feedback_fn == nullptr ||
             owner.span_feedback_fn == nullptr || owner.reconfigure_fn == nullptr ||
             owner.layer_count == 0) {
@@ -1499,8 +1535,8 @@ bool llama_kv_cache::kv_stream_adapt(uint32_t active_tokens, uint32_t query_toke
         return false;
     }
     owner.evaluations_since_repartition = 0;
-    LLAMA_LOG_WARN("%s: adaptive KV partition: resident pages/layer %u -> %u, ring slots %u -> %u, miss %.1f%%, copy busy %.1f%%\n",
-        __func__, resident_pages, target_resident_pages,
+    LLAMA_LOG_WARN("%s: adaptive KV partition on %s: resident pages/layer %u -> %u, ring slots %u -> %u, miss %.1f%%, copy busy %.1f%%\n",
+        __func__, owner.dev != nullptr ? ggml_backend_dev_name(owner.dev) : "?", resident_pages, target_resident_pages,
         ring_slots, target_ring_slots,
         100.0*(delta.valid ? delta.deadline_miss_ratio : 0.0),
         100.0*copy_busy_ratio);
@@ -1789,10 +1825,12 @@ void llama_kv_cache::set_input_k_idxs(ggml_tensor * dst, const llama_ubatch * ub
         }
     }
 
-    if (kv_stream_runtime.runtime != nullptr) {
-        GGML_ASSERT(kv_stream_runtime.mark_dirty_rows_fn != nullptr);
-        GGML_ASSERT(kv_stream_runtime.mark_dirty_rows_fn(
-            kv_stream_runtime.runtime, data, n_tokens));
+    for (auto & owner : kv_stream_runtimes) {
+        if (owner->runtime == nullptr) {
+            continue;
+        }
+        GGML_ASSERT(owner->mark_dirty_rows_fn != nullptr);
+        GGML_ASSERT(owner->mark_dirty_rows_fn(owner->runtime, data, n_tokens));
     }
 }
 

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -5,6 +5,7 @@
 #include "llama-kv-cells.h"
 #include "llama-memory.h"
 
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
@@ -115,7 +116,7 @@ public:
         const  layer_share_cb & share,
         // a model can hold more than one cache, so the tensor names have to stay unique
                  const char *   name_tag = "",
-                         size_t kv_stream_stage_bytes = 0);
+    const std::vector<uint64_t> & kv_stream_stage_bytes = {});
 
     ~llama_kv_cache() = default;
 
@@ -302,6 +303,10 @@ private:
         using decode_layout_fn_t = bool (*)(void *, uint32_t);
         using mark_dirty_rows_fn_t = bool (*)(void *, const int64_t *, size_t);
 
+        // the CUDA device this runtime streams for, and its pinned-host buffer type
+        ggml_backend_dev_t dev = nullptr;
+        ggml_backend_buffer_type_t buft = nullptr;
+
         void * runtime = nullptr;
         void (*free_fn)(void *) = nullptr;
         feedback_fn_t feedback_fn = nullptr;
@@ -328,9 +333,13 @@ private:
         }
     };
 
+    // One runtime per CUDA device that hosts streamed attention layers (a
+    // layer split gives each card its own page pool and host storage).
     // Declared before ctxs_bufs so the custom buffers release their runtime
-    // references before this owner releases the initial reference.
-    kv_stream_runtime_owner kv_stream_runtime;
+    // references before these owners release the initial reference.
+    std::vector<std::unique_ptr<kv_stream_runtime_owner>> kv_stream_runtimes;
+
+    bool kv_stream_adapt_owner(kv_stream_runtime_owner & owner, uint32_t active_tokens, uint32_t query_tokens);
     std::vector<std::pair<ggml_context_ptr, ggml_backend_buffer_ptr>> ctxs_bufs;
 
     // the current index from where we start searching for a free slot in the ring buffer of KV cells (see find_slot())

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -30,7 +30,7 @@ llama_memory_hybrid::llama_memory_hybrid(
                             /* layer filters */
     const layer_filter_cb & filter_attn,
     const layer_filter_cb & filter_recr,
-                     size_t kv_stream_stage_bytes) :
+    const std::vector<uint64_t> & kv_stream_stage_bytes) :
     hparams(model.hparams),
     mem_attn(new llama_kv_cache(
         model,

--- a/src/llama-memory-hybrid.h
+++ b/src/llama-memory-hybrid.h
@@ -40,7 +40,7 @@ public:
                             /* layer filters */
     const layer_filter_cb & filter_attn = nullptr,
     const layer_filter_cb & filter_recr = nullptr,
-                     size_t kv_stream_stage_bytes = 0);
+    const std::vector<uint64_t> & kv_stream_stage_bytes = {});
 
     ~llama_memory_hybrid() = default;
 

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <functional>
+#include <vector>
 
 struct llama_ubatch;
 
@@ -18,7 +19,7 @@ struct llama_memory_params {
     // kv cache
     ggml_type type_k;
     ggml_type type_v;
-    uint64_t kv_stream_stage_bytes;
+    std::vector<uint64_t> kv_stream_stage_bytes; // block-streaming pool per model device (device order); empty = off
 
     // use full-size SWA cache
     bool swa_full;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2622,7 +2622,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params, 
                             /* unified           */ cparams.kv_unified,
                             /* filter_attn       */ std::move(filter_attn),
                             /* filter_recr       */ std::move(filter_recr),
-                            /* kv stream stage   */ arch == LLM_ARCH_QWEN35 ? params.kv_stream_stage_bytes : 0);
+                            /* kv stream stage   */ arch == LLM_ARCH_QWEN35 ? params.kv_stream_stage_bytes : std::vector<uint64_t>{});
                     }
                 } else {
                     llama_kv_cache::layer_filter_cb filter = nullptr;


### PR DESCRIPTION
## Problem

With block KV streaming on, a two-GPU machine has no working way to use the second card:

- `-ts` (whole-layer split) is rejected at load: "block KV streaming requires every attention layer on one CUDA device".
- Keeping all layers on CUDA0 and moving weights with a tensor override (`-ot "blk\..*\.ffn_.*=CUDA1"`, or `=CPU`) loads and runs, but the output is silently wrong: coherent text that ignores the prompt and stops after a few dozen tokens. Nothing is logged.

## Root cause

The CUDA backend plans page streaming once per `graph_compute` (`ggml_cuda_kv_stream_prepare_graph` in `ggml-cuda.cu`) and assumes that graph is the whole forward pass. `ggml_backend_sched` splits the pass at every backend boundary, so with weights elsewhere the backend receives about two fragments per layer. Each fragment ran `ggml_cuda_kv_stream_graph_begin` (`fattn.cu`), which restarts layer numbering at 0, clears the ring slot table, and in prefill relearns the K-pointer to resident-layer table from graph order (`kv_stream_resident_layer`). Different layers then map to the same resident pool region.

Probes at 8K context, 1 GB pool, greedy, Qwen3.8-27B:

| setup | output |
|---|---|
| CUDA0 only, no override | correct (reference) |
| second GPU visible, nothing placed on it | correct |
| all FFN on CUDA1, `--kv-stream-stage-mib 0` | correct |
| one layer's FFN on CUDA1, streaming on | correct |
| all FFN on CUDA1, streaming on | wrong |

The same corruption was seen with all FFN on CPU at a 196K ceiling.

## Change

**Commit 1, survive scheduler graph splits.** `llama-kv-cache` registers each streamed layer's K/V storage with the runtime in model order (`ggml_backend_cuda_kv_stream_register_layer`), so identity no longer comes from node order; the lazy path stays for callers that do not register (`kv-stream-bench`). `llama_context::graph_compute` brackets `ggml_backend_sched_graph_compute_async` with `ggml_backend_cuda_kv_stream_forward_begin` / `_end` per CUDA backend: `begin` plans the full graph once, an armed `graph_compute` only executes nodes, `end` records the end-of-pass timing. Without a bracket the old per-graph path runs unchanged.

**Commit 2, one page pool per CUDA device.** The runtime owner in `llama-kv-cache` becomes a per-device table; each layer's K/V lives in its own device's stream buffer type; repartition and dirty-row marking loop over runtimes; the one-device check is gone. `--kv-stream-stage-mib N[,N...]` gives one pool per model device in `-ts` order (one value applies everywhere, `0` keeps that device's layers in an ordinary VRAM cache), plumbed as `kv_stream_stage_mib_dev` on `llama_context_params` with defaults that keep the old behaviour. The stream buffer type name now carries the device index: `llama-kv-cache` groups KV tensors into contexts by buffer-type name, so with a shared name the second device's layers silently landed in the first device's buffer.

## Validation

RTX 5060 Ti 16 GB + RTX 3060 12 GB, Ryzen 5 7600, 32 GB RAM, CUDA 13.0. Qwen3.8-27B UD-IQ4_XS with a pruned (ASCII-condensed) vocabulary, `-ctk q8_0 -ctv q4_0 -fa on -ub 128 -b 512 -np 1`, `token_embd.weight` on CPU, MTP draft on unless noted.

- Greedy prompts at 8K: `-ts 40,24` and all-FFN-on-CUDA1 both give output identical to the single-device run.
- Needle retrieval, 64K ceiling, 1 GB pools so pages must stream: 3/3 at 25/50/75 % of 60K for the split, the override, and the single-device control.
- `-ts 40,24` loader log: two runtimes (10 + 6 attention layers), two host buffers, 3 graph splits per token.

Decode t/s by tokens in context, 196K ceiling unless noted:

| configuration | 0 | 22K | 45K | 90K | 134K |
|---|---|---|---|---|---|
| single GPU (5060 Ti), 128K ceiling, pool 1 GB | 55 | 46 | 26 | 8.5 | – |
| all FFN on CUDA1, one pool 6 GB (commit 1 only) | 40 | 31 | 32 | 24 | – |
| `-ts 40,24`, pools 5120+4096 MiB | 42 | 37 | 30 | 25 | 21 |
| `-ts 40,24`, pools 5120+5120 MiB, no MTP | 25 | 22 | 19 | 15 | 12.5 |

Prompt processing: 864 t/s on the split, 800-870 single GPU, 379 with the FFN override. The single GPU is faster shallow; the split keeps the pool big enough that decode holds at depth.

## Limitations

- One model (qwen35 arch) and one two-GPU box. Not tested: more than two devices, `-sm row`, the unpruned file, other `-ub`, `-np > 1` (still rejected).
- Per-device budgets are set by hand; no automatic split of one budget by layer count or free VRAM.
- API shape is open: the list could live only on `llama_context_params`, and `forward_begin/_end` could become a generic backend hook instead of a CUDA proc address. Happy to rework.
- Commit 1 stands on its own (it also makes `-ot ... =CPU` overrides safe with streaming on); commit 2 depends on it.

## Notes

Written with an AI coding assistant under my direction and tested on my machine as described. Glad to iterate, split the PR, or add tests you would like.
